### PR TITLE
Remove unavailable 'random' pattern

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -84,7 +84,6 @@ function handleRandomPick(randomDyes: [Dye, Dye, Dye]) {
     'monochromatic',
     'similar',
     'contrast',
-    'random'
   ];
   const randomPattern = patterns[Math.floor(Math.random() * patterns.length)];
   


### PR DESCRIPTION
The current "Random Pick" feature (bcde2e5) has a chance to choose `random` pattern but it isn't public to the user yet and shows an empty selector box.

<img width="634" height="377" alt="image" src="https://github.com/user-attachments/assets/562386db-d44e-483d-93f9-696b3c99e3e2" />
